### PR TITLE
Implement fast verify in demo application

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ cargo run --release --example lms-demo -- genkey mykey 10/2
 # Generates `message.txt.sig`
 cargo run --release --example lms-demo -- sign mykey message.txt
 
+# Signing (fast_verification)
+# Generates `message.txt_mut`, `message.txt_mut.sig`
+cargo run --release --example lms-demo --features fast_verify -- sign_mut mykey message.txt
+
 # Verification
 # Verifies `message.txt` with `message.txt.sig` against `mykey.pub`
 cargo run --release --example lms-demo -- verify mykey message.txt

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ cargo run --release --example lms-demo -- sign mykey message.txt
 
 # Signing (fast_verification)
 # Generates `message.txt_mut`, `message.txt_mut.sig`
-cargo run --release --example lms-demo --features fast_verify -- sign_mut mykey message.txt
+MAX_HASH_OPTIMIZATIONS=1000 THREADS=2 cargo run --release --example lms-demo --features fast_verify -- sign_mut mykey message.txt
 
 # Verification
 # Verifies `message.txt` with `message.txt.sig` against `mykey.pub`


### PR DESCRIPTION
This PR adds the `sign_mut` command to the demo application. This command is used to create a signature and message which can be used for the fast_verify algorithm.