### PR TITLE
Add GH Workflows

### DIFF
--- a/.github/actions/cross-tests/action.yml
+++ b/.github/actions/cross-tests/action.yml
@@ -1,0 +1,35 @@
+name: "cross-tests"
+
+inputs:
+  rust:
+    required: true
+  package:
+    required: true
+  target:
+    required: true
+  features:
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ inputs.rust }}
+          target: ${{ inputs.target }}
+          override: true
+      - name: Install precompiled cross
+        run: |
+          export URL=$(curl -s https://api.github.com/repos/rust-embedded/cross/releases/latest | \
+            jq -r '.assets[] | select(.name | contains("x86_64-unknown-linux-gnu.tar.gz")) | .browser_download_url')
+          wget -O /tmp/binaries.tar.gz $URL
+          tar -C /tmp -xzf /tmp/binaries.tar.gz
+          mv /tmp/cross ~/.cargo/bin
+        shell: bash
+      - run: |
+          # cd ${{ inputs.package }} Not needed, as only a single crate is located in this repository
+          cross test --target ${{ inputs.target }} --no-default-features \
+            --features ${{ inputs.features }}
+        shell: bash

--- a/.github/workflows/lms.yml
+++ b/.github/workflows/lms.yml
@@ -1,0 +1,132 @@
+name: lms
+
+on:
+  pull_request:
+    branches: [ master ]
+  push:
+    branches: [ master ]
+
+env:
+  MSRV: 1.57.0
+  RUSTFLAGS: "-Dwarnings"
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  rustfmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install fmt
+        run: rustup component add rustfmt
+      - name: Run fmt
+        run: |
+          cargo fmt --version
+          cargo fmt --all -- --check
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install clippy
+        run: rustup component add clippy
+      - name: Run clippy
+        run: |
+          cargo clippy --version
+          cargo clippy --all-targets --all-features -- -D warnings
+
+  check-for-todos:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: make check-for-todos
+        continue-on-error: true
+
+  msrv:
+    runs-on: ubuntu-latest
+    outputs:
+      msrv: ${{ steps.msrv.outputs.msrv }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install msrv
+        run: cargo install cargo-msrv
+      - name: Run msrv
+        run: |
+            make check-msrv
+            cargo msrv --verify
+
+  set-msrv:
+    runs-on: ubuntu-latest
+    outputs:
+      msrv: ${{ steps.msrv.outputs.msrv }}
+    steps:
+      - uses: actions/checkout@v2
+      - id: msrv
+        run: echo "::set-output name=msrv::$(grep rust-version Cargo.toml | cut -d'"' -f2-2)"
+
+  build:
+    needs: set-msrv
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - ${{needs.set-msrv.outputs.msrv}}
+          - stable
+        target:
+          - thumbv7em-none-eabi
+          - wasm32-unknown-unknown
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          target: ${{ matrix.target }}
+          override: true
+      - run: cargo build --no-default-features --target ${{ matrix.target }}
+
+  test:
+    needs: set-msrv
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - ${{needs.set-msrv.outputs.msrv}}
+          - stable
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - run: cargo test
+      - run: cargo test -- --include-ignored
+      - run: cargo test --features fast_verify
+      - run: cargo test --features fast_verify -- --include-ignored
+
+  # Cross-compiled tests
+  cross:
+    needs: set-msrv
+    strategy:
+      matrix:
+        rust:
+          - ${{needs.set-msrv.outputs.msrv}}
+          - stable
+        target:
+          - aarch64-unknown-linux-gnu
+          - mips-unknown-linux-gnu
+        features:
+          - default
+
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+      # Cross mounts only current package, i.e. by default it ignores workspace's Cargo.toml
+        working-directory: .
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/cross-tests
+        with:
+          rust: ${{ matrix.rust }}
+          package: ${{ github.workflow }}
+          target: ${{ matrix.target }}
+          features: ${{ matrix.features }}

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ check-for-todos:
 	@git grep -n -i -e todo -e fixme -- \
 	    :^Makefile \
 	    :^.gitlab-ci.yml \
+	    :^.github/ \
 	    2>&1 | tee check_for_todos_results.txt
 
 	@if [ ! -s check_for_todos_results.txt ]; then \

--- a/tests/reference_implementation.rs
+++ b/tests/reference_implementation.rs
@@ -23,6 +23,7 @@ const TEST_SEED: [u8; 32] = [
 ];
 
 #[test]
+#[ignore]
 fn create_signature_with_reference_implementation() {
     let tempdir = tempfile::tempdir().unwrap();
 
@@ -39,6 +40,7 @@ fn create_signature_with_reference_implementation() {
 }
 
 #[test]
+#[ignore]
 fn create_signature_with_own_implementation() {
     let tempdir = tempfile::tempdir().unwrap();
     let path = tempdir.path();
@@ -84,6 +86,7 @@ fn create_signature_with_own_implementation() {
 }
 
 #[test]
+#[ignore]
 fn test_private_key_format() {
     let tempdir = tempfile::tempdir().unwrap();
     let path = tempdir.path();
@@ -103,6 +106,7 @@ fn test_private_key_format() {
 }
 
 #[test]
+#[ignore]
 fn should_produce_same_private_key() {
     let tempdir = tempfile::tempdir().unwrap();
     let path = tempdir.path();
@@ -122,6 +126,7 @@ fn should_produce_same_private_key() {
 }
 
 #[test]
+#[ignore]
 fn should_produce_same_aux_data() {
     let tempdir = tempfile::tempdir().unwrap();
     let path = tempdir.path();


### PR DESCRIPTION
RFC tests needed to be flagged with the `ignore` attribute, as they rely on the x86 binary `tests/demo`. Thus, cross testing is not possible out-of-the box. Nevertheless, the RFC tests are run as part of the `cargo test` job by calling `cargo test -- --include-ignored`