### PR TITLE
Refactor `keygen` to increase performance

### DIFF
--- a/benches/mod.rs
+++ b/benches/mod.rs
@@ -52,6 +52,68 @@ mod tests {
     }
 
     #[bench]
+    fn keygen_h5w2(b: &mut Bencher) {
+        let mut seed = Seed::default();
+        OsRng.fill_bytes(&mut seed);
+        let hss_parameter = [HssParameter::new(
+            LmotsAlgorithm::LmotsW2,
+            LmsAlgorithm::LmsH5,
+        )];
+
+        b.iter(|| {
+            let _ = keygen::<Sha256>(&hss_parameter, &seed, None);
+        });
+    }
+
+    #[bench]
+    fn keygen_with_aux_h5w2(b: &mut Bencher) {
+        let mut seed = Seed::default();
+        OsRng.fill_bytes(&mut seed);
+        let hss_parameter = [HssParameter::new(
+            LmotsAlgorithm::LmotsW2,
+            LmsAlgorithm::LmsH5,
+        )];
+
+        b.iter(|| {
+            let mut aux_data = vec![0u8; 100_000];
+            let aux_slice: &mut &mut [u8] = &mut &mut aux_data[..];
+
+            let _ = keygen::<Sha256>(&hss_parameter, &seed, Some(aux_slice));
+        });
+    }
+
+    #[bench]
+    fn keygen_h5w2_h5w2(b: &mut Bencher) {
+        let mut seed = Seed::default();
+        OsRng.fill_bytes(&mut seed);
+        let hss_parameter = [
+            HssParameter::new(LmotsAlgorithm::LmotsW2, LmsAlgorithm::LmsH5),
+            HssParameter::new(LmotsAlgorithm::LmotsW2, LmsAlgorithm::LmsH5),
+        ];
+
+        b.iter(|| {
+            let _ = keygen::<Sha256>(&hss_parameter, &seed, None);
+        });
+    }
+
+    #[bench]
+    fn keygen_with_aux_h5w2_h5w2(b: &mut Bencher) {
+        let mut seed = Seed::default();
+        OsRng.fill_bytes(&mut seed);
+        let hss_parameter = [
+            HssParameter::new(LmotsAlgorithm::LmotsW2, LmsAlgorithm::LmsH5),
+            HssParameter::new(LmotsAlgorithm::LmotsW2, LmsAlgorithm::LmsH5),
+        ];
+
+        b.iter(|| {
+            let mut aux_data = vec![0u8; 100_000];
+            let aux_slice: &mut &mut [u8] = &mut &mut aux_data[..];
+
+            let _ = keygen::<Sha256>(&hss_parameter, &seed, Some(aux_slice));
+        });
+    }
+
+    #[bench]
     fn sign(b: &mut Bencher) {
         let mut signing_key = generate_signing_key(None);
 

--- a/src/hss/mod.rs
+++ b/src/hss/mod.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 use self::{
-    definitions::{HssPrivateKey, InMemoryHssPublicKey},
+    definitions::{HssPrivateKey, HssPublicKey, InMemoryHssPublicKey},
     parameter::HssParameter,
     reference_impl_private_key::ReferenceImplPrivateKey,
     signing::{HssSignature, InMemoryHssSignature},
@@ -261,11 +261,10 @@ pub fn hss_keygen<H: HashChain>(
     let private_key =
         ReferenceImplPrivateKey::generate(parameters, seed).map_err(|_| Error::new())?;
 
-    let hss_key = HssPrivateKey::from(&private_key, aux_data).map_err(|_| Error::new())?;
+    let hss_public_key = HssPublicKey::from(&private_key, aux_data).map_err(|_| Error::new())?;
 
     let signing_key = SigningKey::from_bytes(&private_key.to_binary_representation())?;
-    let verifying_key =
-        VerifyingKey::from_bytes(&hss_key.get_public_key().to_binary_representation())?;
+    let verifying_key = VerifyingKey::from_bytes(&hss_public_key.to_binary_representation())?;
     Ok((signing_key, verifying_key))
 }
 


### PR DESCRIPTION
`keygen` generates a not needed working `HssPrivateKey` including the subtree `public_keys` and its `signatures`