### PR TITLE
Variable sized Hash support

### DIFF
--- a/benches/mod.rs
+++ b/benches/mod.rs
@@ -6,7 +6,7 @@ mod tests {
     use rand::{rngs::OsRng, RngCore};
     use test::Bencher;
 
-    use hbs_lms::{keygen, HssParameter, LmotsAlgorithm, LmsAlgorithm, Seed, Sha256};
+    use hbs_lms::{keygen, HssParameter, LmotsAlgorithm, LmsAlgorithm, Seed, Sha256_256};
     use hbs_lms::{
         signature::{SignerMut, Verifier},
         Signature, SigningKey, VerifierSignature, VerifyingKey,
@@ -17,21 +17,21 @@ mod tests {
     ];
 
     fn generate_signing_key(
-        hss_parameter: &[HssParameter<Sha256>],
+        hss_parameter: &[HssParameter<Sha256_256>],
         aux_data: Option<&mut &mut [u8]>,
-    ) -> SigningKey<Sha256> {
+    ) -> SigningKey<Sha256_256> {
         let mut seed = Seed::default();
-        OsRng.fill_bytes(&mut seed);
+        OsRng.fill_bytes(seed.as_mut_slice());
 
-        let (signing_key, _) = keygen::<Sha256>(hss_parameter, &seed, aux_data).unwrap();
+        let (signing_key, _) = keygen::<Sha256_256>(hss_parameter, &seed, aux_data).unwrap();
 
         signing_key
     }
 
-    fn generate_verifying_key_and_signature() -> (VerifyingKey<Sha256>, Signature) {
+    fn generate_verifying_key_and_signature() -> (VerifyingKey<Sha256_256>, Signature) {
         let mut seed = Seed::default();
-        OsRng.fill_bytes(&mut seed);
-        let (mut signing_key, verifying_key) = keygen::<Sha256>(
+        OsRng.fill_bytes(seed.as_mut_slice());
+        let (mut signing_key, verifying_key) = keygen::<Sha256_256>(
             &[HssParameter::new(
                 LmotsAlgorithm::LmotsW2,
                 LmsAlgorithm::LmsH5,
@@ -49,21 +49,21 @@ mod tests {
     #[bench]
     fn keygen_h5w2(b: &mut Bencher) {
         let mut seed = Seed::default();
-        OsRng.fill_bytes(&mut seed);
+        OsRng.fill_bytes(seed.as_mut_slice());
         let hss_parameter = [HssParameter::new(
             LmotsAlgorithm::LmotsW2,
             LmsAlgorithm::LmsH5,
         )];
 
         b.iter(|| {
-            let _ = keygen::<Sha256>(&hss_parameter, &seed, None);
+            let _ = keygen::<Sha256_256>(&hss_parameter, &seed, None);
         });
     }
 
     #[bench]
     fn keygen_with_aux_h5w2(b: &mut Bencher) {
         let mut seed = Seed::default();
-        OsRng.fill_bytes(&mut seed);
+        OsRng.fill_bytes(seed.as_mut_slice());
         let hss_parameter = [HssParameter::new(
             LmotsAlgorithm::LmotsW2,
             LmsAlgorithm::LmsH5,
@@ -73,28 +73,28 @@ mod tests {
             let mut aux_data = vec![0u8; 100_000];
             let aux_slice: &mut &mut [u8] = &mut &mut aux_data[..];
 
-            let _ = keygen::<Sha256>(&hss_parameter, &seed, Some(aux_slice));
+            let _ = keygen::<Sha256_256>(&hss_parameter, &seed, Some(aux_slice));
         });
     }
 
     #[bench]
     fn keygen_h5w2_h5w2(b: &mut Bencher) {
         let mut seed = Seed::default();
-        OsRng.fill_bytes(&mut seed);
+        OsRng.fill_bytes(seed.as_mut_slice());
         let hss_parameter = [
             HssParameter::new(LmotsAlgorithm::LmotsW2, LmsAlgorithm::LmsH5),
             HssParameter::new(LmotsAlgorithm::LmotsW2, LmsAlgorithm::LmsH5),
         ];
 
         b.iter(|| {
-            let _ = keygen::<Sha256>(&hss_parameter, &seed, None);
+            let _ = keygen::<Sha256_256>(&hss_parameter, &seed, None);
         });
     }
 
     #[bench]
     fn keygen_with_aux_h5w2_h5w2(b: &mut Bencher) {
         let mut seed = Seed::default();
-        OsRng.fill_bytes(&mut seed);
+        OsRng.fill_bytes(seed.as_mut_slice());
         let hss_parameter = [
             HssParameter::new(LmotsAlgorithm::LmotsW2, LmsAlgorithm::LmsH5),
             HssParameter::new(LmotsAlgorithm::LmotsW2, LmsAlgorithm::LmsH5),
@@ -104,7 +104,7 @@ mod tests {
             let mut aux_data = vec![0u8; 100_000];
             let aux_slice: &mut &mut [u8] = &mut &mut aux_data[..];
 
-            let _ = keygen::<Sha256>(&hss_parameter, &seed, Some(aux_slice));
+            let _ = keygen::<Sha256_256>(&hss_parameter, &seed, Some(aux_slice));
         });
     }
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -7,7 +7,6 @@ pub const ILEN: usize = 16;
 pub const MAX_SEED_LEN: usize = 32;
 
 pub type LmsTreeIdentifier = [u8; ILEN];
-pub type Seed = ArrayVec<[u8; MAX_SEED_LEN]>;
 pub type LmsLeafIdentifier = [u8; 4];
 
 type FvcMax = u16;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -4,10 +4,10 @@ use tinyvec::ArrayVec;
 include!(concat!(env!("OUT_DIR"), "/constants.rs"));
 
 pub const ILEN: usize = 16;
-pub const SEED_LEN: usize = 32;
+pub const MAX_SEED_LEN: usize = 32;
 
 pub type LmsTreeIdentifier = [u8; ILEN];
-pub type Seed = [u8; SEED_LEN];
+pub type Seed = ArrayVec<[u8; MAX_SEED_LEN]>;
 pub type LmsLeafIdentifier = [u8; 4];
 
 type FvcMax = u16;
@@ -41,8 +41,8 @@ pub const fn prng_len(seed_len: usize) -> usize {
 
 pub const LMS_LEAF_IDENTIFIERS_SIZE: usize = 8;
 pub const REF_IMPL_MAX_ALLOWED_HSS_LEVELS: usize = 8;
-pub const REFERENCE_IMPL_PRIVATE_KEY_SIZE: usize =
-    LMS_LEAF_IDENTIFIERS_SIZE + REF_IMPL_MAX_ALLOWED_HSS_LEVELS + size_of::<Seed>();
+pub const REF_IMPL_MAX_PRIVATE_KEY_SIZE: usize =
+    LMS_LEAF_IDENTIFIERS_SIZE + REF_IMPL_MAX_ALLOWED_HSS_LEVELS + MAX_SEED_LEN;
 
 pub const MAX_HASH_SIZE: usize = 32;
 pub const MAX_HASH_BLOCK_SIZE: usize = 64;

--- a/src/hasher/mod.rs
+++ b/src/hasher/mod.rs
@@ -12,11 +12,11 @@ pub mod sha256;
 pub mod shake256;
 
 pub struct HashChainData {
-    data: [u8; ITER_MAX_LEN],
+    data: ArrayVec<[u8; ITER_MAX_LEN]>,
 }
 
 impl Deref for HashChainData {
-    type Target = [u8; ITER_MAX_LEN];
+    type Target = ArrayVec<[u8; ITER_MAX_LEN]>;
 
     fn deref(&self) -> &Self::Target {
         &self.data
@@ -53,8 +53,9 @@ pub trait HashChain:
         lms_leaf_identifier: &[u8],
     ) -> HashChainData {
         let mut hc_data = HashChainData {
-            data: [0u8; ITER_MAX_LEN],
+            data: ArrayVec::new(),
         };
+        hc_data.resize(iter_len(Self::OUTPUT_SIZE as usize), 0u8);
         hc_data[ITER_I..ITER_Q].copy_from_slice(lms_tree_identifier);
         hc_data[ITER_Q..ITER_K].copy_from_slice(lms_leaf_identifier);
         hc_data

--- a/src/hasher/mod.rs
+++ b/src/hasher/mod.rs
@@ -53,9 +53,11 @@ pub trait HashChain:
         lms_leaf_identifier: &[u8],
     ) -> HashChainData {
         let mut hc_data = HashChainData {
-            data: ArrayVec::new(),
+            data: ArrayVec::from_array_len(
+                [0u8; ITER_MAX_LEN],
+                iter_len(Self::OUTPUT_SIZE as usize),
+            ),
         };
-        hc_data.resize(iter_len(Self::OUTPUT_SIZE as usize), 0u8);
         hc_data[ITER_I..ITER_Q].copy_from_slice(lms_tree_identifier);
         hc_data[ITER_Q..ITER_K].copy_from_slice(lms_leaf_identifier);
         hc_data

--- a/src/hasher/sha256.rs
+++ b/src/hasher/sha256.rs
@@ -10,57 +10,71 @@ use crate::constants::MAX_HASH_SIZE;
 
 use super::HashChain;
 
-/**
- * Extension of [`sha2::Sha256`], which can be passed into the library, as it implements the [`HashChain`] trait.
- * */
-#[derive(Debug, Default, Clone)]
-pub struct Sha256 {
-    hasher: Hasher,
+macro_rules! define_sha {
+    ($name:ident, $output_size:expr) => {
+        /**
+         * Extension of [`sha2::Sha256`], which can be passed into the library, as it implements the [`HashChain`] trait.
+         * */
+        #[derive(Debug, Default, Clone)]
+        pub struct $name {
+            hasher: Hasher,
+        }
+
+        impl HashChain for $name {
+            const OUTPUT_SIZE: u16 = $output_size;
+            const BLOCK_SIZE: u16 = 64;
+
+            fn finalize(self) -> ArrayVec<[u8; MAX_HASH_SIZE]> {
+                ArrayVec::try_from(&self.hasher.finalize_fixed()[..(Self::OUTPUT_SIZE as usize)])
+                    .unwrap()
+            }
+
+            fn finalize_reset(&mut self) -> ArrayVec<[u8; MAX_HASH_SIZE]> {
+                ArrayVec::try_from(
+                    &self.hasher.finalize_fixed_reset()[..(Self::OUTPUT_SIZE as usize)],
+                )
+                .unwrap()
+            }
+        }
+
+        impl OutputSizeUser for $name {
+            type OutputSize = U32;
+        }
+
+        impl FixedOutput for $name {
+            fn finalize_into(self, out: &mut Output<Self>) {
+                *out = self.hasher.finalize_fixed();
+            }
+        }
+
+        impl Reset for $name {
+            fn reset(&mut self) {
+                *self = Default::default();
+            }
+        }
+
+        impl FixedOutputReset for $name {
+            fn finalize_into_reset(&mut self, out: &mut Output<Self>) {
+                *out = self.hasher.finalize_fixed_reset();
+            }
+        }
+
+        impl Update for $name {
+            fn update(&mut self, data: &[u8]) {
+                self.hasher.update(data);
+            }
+        }
+
+        impl PartialEq for $name {
+            fn eq(&self, _: &Self) -> bool {
+                false
+            }
+        }
+    };
 }
 
-impl HashChain for Sha256 {
-    const OUTPUT_SIZE: u16 = 32;
-    const BLOCK_SIZE: u16 = 64;
+define_sha!(Sha256_256, 32);
 
-    fn finalize(self) -> ArrayVec<[u8; MAX_HASH_SIZE]> {
-        ArrayVec::try_from(self.hasher.finalize_fixed().as_slice()).unwrap()
-    }
+define_sha!(Sha256_192, 24);
 
-    fn finalize_reset(&mut self) -> ArrayVec<[u8; MAX_HASH_SIZE]> {
-        ArrayVec::try_from(self.hasher.finalize_fixed_reset().as_slice()).unwrap()
-    }
-}
-
-impl OutputSizeUser for Sha256 {
-    type OutputSize = U32;
-}
-
-impl FixedOutput for Sha256 {
-    fn finalize_into(self, out: &mut Output<Self>) {
-        *out = self.hasher.finalize_fixed();
-    }
-}
-
-impl Reset for Sha256 {
-    fn reset(&mut self) {
-        *self = Default::default();
-    }
-}
-
-impl FixedOutputReset for Sha256 {
-    fn finalize_into_reset(&mut self, out: &mut Output<Self>) {
-        *out = self.hasher.finalize_fixed_reset();
-    }
-}
-
-impl Update for Sha256 {
-    fn update(&mut self, data: &[u8]) {
-        self.hasher.update(data);
-    }
-}
-
-impl PartialEq for Sha256 {
-    fn eq(&self, _: &Self) -> bool {
-        false
-    }
-}
+define_sha!(Sha256_128, 16);

--- a/src/hss/aux.rs
+++ b/src/hss/aux.rs
@@ -262,21 +262,19 @@ fn compute_hmac<H: HashChain>(key: &[u8], data: &[u8]) -> ArrayVec<[u8; MAX_HASH
 
 #[cfg(test)]
 mod tests {
-    use rand::{rngs::OsRng, RngCore};
-
-    use crate::hasher::sha256::Sha256;
+    use crate::hasher::sha256::Sha256_256;
+    use crate::util::helper::test_helper::gen_random_seed;
     use crate::{
         constants::MAX_HASH_SIZE,
         hss::{aux::hss_expand_aux_data, hss_keygen},
-        HssParameter, LmotsAlgorithm, LmsAlgorithm, Seed,
+        HssParameter, LmotsAlgorithm, LmsAlgorithm,
     };
 
     #[test]
     #[should_panic(expected = "expand_aux_data should return None!")]
     fn expand_aux_data_with_forged_aux_data() {
-        let mut seed = Seed::default();
-        OsRng.fill_bytes(&mut seed);
-        type H = Sha256;
+        type H = Sha256_256;
+        let seed = gen_random_seed::<H>();
 
         let lmots = LmotsAlgorithm::LmotsW2;
         let lms = LmsAlgorithm::LmsH5;
@@ -290,7 +288,7 @@ mod tests {
 
         aux_slice[2 * MAX_HASH_SIZE - 1] ^= 1;
 
-        hss_expand_aux_data::<H>(Some(aux_slice), Some(&seed))
+        hss_expand_aux_data::<H>(Some(aux_slice), Some(seed.as_slice()))
             .expect("expand_aux_data should return None!");
     }
 }

--- a/src/hss/mod.rs
+++ b/src/hss/mod.rs
@@ -294,7 +294,7 @@ mod tests {
     use crate::util::helper::test_helper::gen_random_seed;
     use crate::{
         constants::{LMS_LEAF_IDENTIFIERS_SIZE, MAX_HASH_SIZE},
-        hasher::{sha256::*, shake256::Shake256, HashChain},
+        hasher::{sha256::{Sha256_128, Sha256_192, Sha256_256}, shake256::Shake256, HashChain},
         LmotsAlgorithm, LmsAlgorithm,
     };
 

--- a/src/hss/mod.rs
+++ b/src/hss/mod.rs
@@ -294,7 +294,11 @@ mod tests {
     use crate::util::helper::test_helper::gen_random_seed;
     use crate::{
         constants::{LMS_LEAF_IDENTIFIERS_SIZE, MAX_HASH_SIZE},
-        hasher::{sha256::{Sha256_128, Sha256_192, Sha256_256}, shake256::Shake256, HashChain},
+        hasher::{
+            sha256::{Sha256_128, Sha256_192, Sha256_256},
+            shake256::Shake256,
+            HashChain,
+        },
         LmotsAlgorithm, LmsAlgorithm,
     };
 

--- a/src/hss/verify.rs
+++ b/src/hss/verify.rs
@@ -31,23 +31,23 @@ pub fn verify<'a, H: HashChain>(
 #[cfg(test)]
 mod tests {
     use crate::{
-        hasher::{sha256::Sha256, HashChain},
+        hasher::{sha256::Sha256_256, HashChain},
         hss::{
             definitions::{HssPrivateKey, HssPublicKey, InMemoryHssPublicKey},
             reference_impl_private_key::ReferenceImplPrivateKey,
             signing::{HssSignature, InMemoryHssSignature},
             verify::verify,
         },
-        HssParameter, Seed,
+        HssParameter,
     };
 
-    use rand::{rngs::OsRng, RngCore};
+    use crate::util::helper::test_helper::gen_random_seed;
 
     #[test]
     fn test_hss_verify() {
-        let mut seed = Seed::default();
-        OsRng.fill_bytes(&mut seed);
-        let rfc_key = ReferenceImplPrivateKey::<Sha256>::generate(
+        type H = Sha256_256;
+        let seed = gen_random_seed::<H>();
+        let rfc_key = ReferenceImplPrivateKey::<H>::generate(
             &[
                 HssParameter::construct_default_parameters(),
                 HssParameter::construct_default_parameters(),

--- a/src/lm_ots/definitions.rs
+++ b/src/lm_ots/definitions.rs
@@ -56,14 +56,14 @@ impl<H: HashChain> LmotsPublicKey<H> {
 
 #[cfg(test)]
 mod tests {
-    use crate::hasher::sha256::Sha256;
+    use crate::hasher::sha256::{Sha256_128, Sha256_192, Sha256_256};
     use crate::lm_ots::parameters;
 
     macro_rules! generate_parameter_test {
-        ($name:ident, $parameter:expr, $n:literal, $w:literal, $p:literal, $ls:literal, $type:literal) => {
+        ($name:ident, $parameter:expr, $hash_chain:ty, $n:literal, $w:literal, $p:literal, $ls:literal, $type:literal) => {
             #[test]
             fn $name() {
-                let parameter = $parameter.construct_parameter::<Sha256>().unwrap();
+                let parameter = $parameter.construct_parameter::<$hash_chain>().unwrap();
                 assert_eq!(parameter.get_hash_function_output_size(), $n);
                 assert_eq!(parameter.get_winternitz(), $w);
                 assert_eq!(parameter.get_hash_chain_count(), $p);
@@ -76,6 +76,7 @@ mod tests {
     generate_parameter_test!(
         lmots_sha256_n32_w1_parameter_test,
         parameters::LmotsAlgorithm::LmotsW1,
+        Sha256_256,
         32,
         1,
         265,
@@ -83,8 +84,29 @@ mod tests {
         1
     );
     generate_parameter_test!(
+        lmots_sha256_n24_w1_parameter_test,
+        parameters::LmotsAlgorithm::LmotsW1,
+        Sha256_192,
+        24,
+        1,
+        200,
+        7,
+        1
+    );
+    generate_parameter_test!(
+        lmots_sha256_n16_w1_parameter_test,
+        parameters::LmotsAlgorithm::LmotsW1,
+        Sha256_128,
+        16,
+        1,
+        136,
+        7,
+        1
+    );
+    generate_parameter_test!(
         lmots_sha256_n32_w2_parameter_test,
         parameters::LmotsAlgorithm::LmotsW2,
+        Sha256_256,
         32,
         2,
         133,
@@ -92,8 +114,29 @@ mod tests {
         2
     );
     generate_parameter_test!(
+        lmots_sha256_n24_w2_parameter_test,
+        parameters::LmotsAlgorithm::LmotsW2,
+        Sha256_192,
+        24,
+        2,
+        101,
+        6,
+        2
+    );
+    generate_parameter_test!(
+        lmots_sha256_n16_w2_parameter_test,
+        parameters::LmotsAlgorithm::LmotsW2,
+        Sha256_128,
+        16,
+        2,
+        68,
+        6,
+        2
+    );
+    generate_parameter_test!(
         lmots_sha256_n32_w4_parameter_test,
         parameters::LmotsAlgorithm::LmotsW4,
+        Sha256_256,
         32,
         4,
         67,
@@ -101,11 +144,52 @@ mod tests {
         3
     );
     generate_parameter_test!(
+        lmots_sha256_n24_w4_parameter_test,
+        parameters::LmotsAlgorithm::LmotsW4,
+        Sha256_192,
+        24,
+        4,
+        51,
+        4,
+        3
+    );
+    generate_parameter_test!(
+        lmots_sha256_n16_w4_parameter_test,
+        parameters::LmotsAlgorithm::LmotsW4,
+        Sha256_128,
+        16,
+        4,
+        35,
+        4,
+        3
+    );
+    generate_parameter_test!(
         lmots_sha256_n32_w8_parameter_test,
         parameters::LmotsAlgorithm::LmotsW8,
+        Sha256_256,
         32,
         8,
         34,
+        0,
+        4
+    );
+    generate_parameter_test!(
+        lmots_sha256_n24_w8_parameter_test,
+        parameters::LmotsAlgorithm::LmotsW8,
+        Sha256_192,
+        24,
+        8,
+        26,
+        0,
+        4
+    );
+    generate_parameter_test!(
+        lmots_sha256_n16_w8_parameter_test,
+        parameters::LmotsAlgorithm::LmotsW8,
+        Sha256_128,
+        16,
+        8,
+        18,
         0,
         4
     );

--- a/src/lm_ots/keygen.rs
+++ b/src/lm_ots/keygen.rs
@@ -3,12 +3,13 @@ use super::parameters::LmotsParameter;
 use crate::constants::*;
 use crate::constants::{D_PBLC, MAX_HASH_CHAIN_COUNT, MAX_HASH_SIZE};
 use crate::hasher::HashChain;
+use crate::Seed;
 use tinyvec::ArrayVec;
 
 pub fn generate_private_key<H: HashChain>(
     lms_tree_identifier: LmsTreeIdentifier,
     lms_leaf_identifier: LmsLeafIdentifier,
-    seed: Seed,
+    seed: Seed<H>,
     lmots_parameter: LmotsParameter<H>,
 ) -> LmotsPrivateKey<H> {
     let mut key = ArrayVec::new();
@@ -20,7 +21,7 @@ pub fn generate_private_key<H: HashChain>(
         hasher.update(&lms_leaf_identifier);
         hasher.update(&(index as u16).to_be_bytes());
         hasher.update(&[0xff]);
-        hasher.update(&seed);
+        hasher.update(seed.as_slice());
 
         key.push(hasher.finalize_reset());
     }

--- a/src/lm_ots/parameters.rs
+++ b/src/lm_ots/parameters.rs
@@ -2,12 +2,10 @@ use core::marker::PhantomData;
 
 use tinyvec::ArrayVec;
 
+use crate::constants::get_hash_chain_count;
 use crate::{
-    constants::{
-        FastVerifyCached, HASH_CHAIN_COUNT_W1, HASH_CHAIN_COUNT_W2, HASH_CHAIN_COUNT_W4,
-        HASH_CHAIN_COUNT_W8, MAX_HASH_SIZE,
-    },
-    hasher::{sha256::Sha256, HashChain},
+    constants::{FastVerifyCached, MAX_HASH_SIZE},
+    hasher::HashChain,
     util::coef::coef,
 };
 
@@ -42,17 +40,37 @@ impl From<u32> for LmotsAlgorithm {
 }
 
 impl LmotsAlgorithm {
-    pub fn construct_default_parameter() -> LmotsParameter {
+    pub fn construct_default_parameter<H: HashChain>() -> LmotsParameter<H> {
         LmotsAlgorithm::LmotsW1.construct_parameter().unwrap()
     }
 
     pub fn construct_parameter<H: HashChain>(&self) -> Option<LmotsParameter<H>> {
         match *self {
             LmotsAlgorithm::LmotsReserved => None,
-            LmotsAlgorithm::LmotsW1 => Some(LmotsParameter::new(1, 1, HASH_CHAIN_COUNT_W1, 7)),
-            LmotsAlgorithm::LmotsW2 => Some(LmotsParameter::new(2, 2, HASH_CHAIN_COUNT_W2, 6)),
-            LmotsAlgorithm::LmotsW4 => Some(LmotsParameter::new(3, 4, HASH_CHAIN_COUNT_W4, 4)),
-            LmotsAlgorithm::LmotsW8 => Some(LmotsParameter::new(4, 8, HASH_CHAIN_COUNT_W8, 0)),
+            LmotsAlgorithm::LmotsW1 => Some(LmotsParameter::new(
+                1,
+                1,
+                get_hash_chain_count(1, H::OUTPUT_SIZE as usize) as u16,
+                7,
+            )),
+            LmotsAlgorithm::LmotsW2 => Some(LmotsParameter::new(
+                2,
+                2,
+                get_hash_chain_count(2, H::OUTPUT_SIZE as usize) as u16,
+                6,
+            )),
+            LmotsAlgorithm::LmotsW4 => Some(LmotsParameter::new(
+                3,
+                4,
+                get_hash_chain_count(4, H::OUTPUT_SIZE as usize) as u16,
+                4,
+            )),
+            LmotsAlgorithm::LmotsW8 => Some(LmotsParameter::new(
+                4,
+                8,
+                get_hash_chain_count(8, H::OUTPUT_SIZE as usize) as u16,
+                0,
+            )),
         }
     }
 
@@ -68,7 +86,7 @@ impl LmotsAlgorithm {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct LmotsParameter<H: HashChain = Sha256> {
+pub struct LmotsParameter<H: HashChain> {
     type_id: u32,
     winternitz: u8,
     hash_chain_count: u16,

--- a/src/lm_ots/signing.rs
+++ b/src/lm_ots/signing.rs
@@ -378,6 +378,12 @@ mod tests {
                 };
 
                 let binary_rep = signature.to_binary_representation();
+
+                // check signature len
+                let output_size = lmots_parameter.get_hash_function_output_size() as usize;
+                let hash_chain_count = lmots_parameter.get_hash_chain_count() as usize;
+                assert_eq!(binary_rep.len(), 4 + output_size * (hash_chain_count + 1));
+
                 let deserialized_signature = InMemoryLmotsSignature::new(binary_rep.as_slice())
                     .expect("Deserialization must succeed.");
 

--- a/src/lms/definitions.rs
+++ b/src/lms/definitions.rs
@@ -1,12 +1,12 @@
 use crate::constants::*;
 use crate::hasher::HashChain;
-use crate::lm_ots;
 use crate::lm_ots::definitions::LmotsPrivateKey;
 use crate::lm_ots::parameters::{LmotsAlgorithm, LmotsParameter};
 use crate::lms::helper::get_tree_element;
 use crate::lms::parameters::LmsAlgorithm;
 use crate::lms::MutableExpandedAuxData;
 use crate::util::helper::read_and_advance;
+use crate::{lm_ots, Seed};
 
 use core::convert::TryInto;
 use tinyvec::ArrayVec;
@@ -17,14 +17,14 @@ use super::parameters::LmsParameter;
 pub struct LmsPrivateKey<H: HashChain> {
     pub lms_tree_identifier: LmsTreeIdentifier,
     pub used_leafs_index: u32,
-    pub seed: Seed,
+    pub seed: Seed<H>,
     pub lmots_parameter: LmotsParameter<H>,
     pub lms_parameter: LmsParameter<H>,
 }
 
 impl<H: HashChain> LmsPrivateKey<H> {
     pub fn new(
-        seed: Seed,
+        seed: Seed<H>,
         lms_tree_identifier: LmsTreeIdentifier,
         used_leafs_index: u32,
         lmots_parameter: LmotsParameter<H>,
@@ -162,7 +162,7 @@ mod tests {
     #[test]
     fn test_public_key_binary_representation() {
         let mut seed_and_lms_tree_identifier = SeedAndLmsTreeIdentifier::default();
-        OsRng.fill_bytes(&mut seed_and_lms_tree_identifier.seed);
+        OsRng.fill_bytes(seed_and_lms_tree_identifier.seed.as_mut_slice());
         let private_key = LmsPrivateKey::new(
             seed_and_lms_tree_identifier.seed,
             seed_and_lms_tree_identifier.lms_tree_identifier,

--- a/src/lms/mod.rs
+++ b/src/lms/mod.rs
@@ -17,7 +17,7 @@ pub struct LmsKeyPair<H: HashChain> {
 }
 
 pub fn generate_key_pair<H: HashChain>(
-    seed: &SeedAndLmsTreeIdentifier,
+    seed: &SeedAndLmsTreeIdentifier<H>,
     parameter: &HssParameter<H>,
     used_leafs_index: &u32,
     aux_data: &mut Option<MutableExpandedAuxData>,

--- a/src/lms/parameters.rs
+++ b/src/lms/parameters.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use crate::hasher::{sha256::Sha256, HashChain};
+use crate::hasher::{sha256::Sha256_256, HashChain};
 
 /// Specifies the used Tree height.
 #[derive(Clone, Copy)]
@@ -37,7 +37,7 @@ impl From<u32> for LmsAlgorithm {
 }
 
 impl LmsAlgorithm {
-    pub fn construct_default_parameter() -> LmsParameter {
+    pub fn construct_default_parameter() -> LmsParameter<Sha256_256> {
         LmsAlgorithm::LmsH5.construct_parameter().unwrap()
     }
 
@@ -69,7 +69,7 @@ impl LmsAlgorithm {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct LmsParameter<H: HashChain = Sha256> {
+pub struct LmsParameter<H: HashChain> {
     type_id: u32,
     tree_height: u8,
     phantom_data: PhantomData<H>,

--- a/src/lms/signing.rs
+++ b/src/lms/signing.rs
@@ -179,10 +179,9 @@ impl<'a, H: HashChain> InMemoryLmsSignature<'a, H> {
         ))
         .unwrap();
 
-        let lms_parameter = LmsAlgorithm::get_from_type(u32::from_be_bytes(
-            read_and_advance(data, 4, &mut index).try_into().unwrap(),
-        ))
-        .unwrap();
+        let _type = u32::from_be_bytes(read_and_advance(data, 4, &mut index).try_into().unwrap());
+
+        let lms_parameter = LmsAlgorithm::get_from_type(_type).unwrap();
         let authentication_path = read_and_advance(
             data,
             (H::OUTPUT_SIZE * lms_parameter.get_tree_height() as u16) as usize,

--- a/src/lms/signing.rs
+++ b/src/lms/signing.rs
@@ -226,7 +226,7 @@ mod tests {
     #[test]
     fn test_binary_representation_of_signature() {
         let mut seed_and_lms_tree_identifier = SeedAndLmsTreeIdentifier::default();
-        OsRng.fill_bytes(&mut seed_and_lms_tree_identifier.seed);
+        OsRng.fill_bytes(seed_and_lms_tree_identifier.seed.as_mut_slice());
         let mut private_key = LmsPrivateKey::new(
             seed_and_lms_tree_identifier.seed,
             seed_and_lms_tree_identifier.lms_tree_identifier,

--- a/src/lms/verify.rs
+++ b/src/lms/verify.rs
@@ -101,7 +101,7 @@ mod tests {
         type Hasher = Sha256_256;
 
         let mut seed_and_lms_tree_identifier = SeedAndLmsTreeIdentifier::default();
-        OsRng.fill_bytes(&mut seed_and_lms_tree_identifier.seed);
+        OsRng.fill_bytes(seed_and_lms_tree_identifier.seed.as_mut_slice());
         let mut private_key = LmsPrivateKey::new(
             seed_and_lms_tree_identifier.seed,
             seed_and_lms_tree_identifier.lms_tree_identifier,

--- a/src/lms/verify.rs
+++ b/src/lms/verify.rs
@@ -90,7 +90,7 @@ mod tests {
             signing::{InMemoryLmsSignature, LmsSignature},
             SeedAndLmsTreeIdentifier,
         },
-        Sha256,
+        Sha256_256,
     };
 
     use rand::{rngs::OsRng, RngCore};
@@ -98,7 +98,7 @@ mod tests {
 
     #[test]
     fn test_verification() {
-        type Hasher = Sha256;
+        type Hasher = Sha256_256;
 
         let mut seed_and_lms_tree_identifier = SeedAndLmsTreeIdentifier::default();
         OsRng.fill_bytes(&mut seed_and_lms_tree_identifier.seed);

--- a/src/util/helper.rs
+++ b/src/util/helper.rs
@@ -11,3 +11,17 @@ pub fn read_and_advance<'a>(src: &'a [u8], length: usize, index: &mut usize) -> 
     *index += length;
     result
 }
+
+#[cfg(test)]
+pub mod test_helper {
+    use crate::constants::MAX_SEED_LEN;
+    use crate::{HashChain, Seed};
+    use rand::{rngs::OsRng, RngCore};
+    use tinyvec::ArrayVec;
+
+    pub fn gen_random_seed<H: HashChain>() -> Seed {
+        let mut seed = ArrayVec::from_array_len([0u8; MAX_SEED_LEN], H::OUTPUT_SIZE as usize);
+        OsRng.fill_bytes(seed.as_mut_slice());
+        seed
+    }
+}

--- a/src/util/helper.rs
+++ b/src/util/helper.rs
@@ -14,13 +14,11 @@ pub fn read_and_advance<'a>(src: &'a [u8], length: usize, index: &mut usize) -> 
 
 #[cfg(test)]
 pub mod test_helper {
-    use crate::constants::MAX_SEED_LEN;
     use crate::{HashChain, Seed};
     use rand::{rngs::OsRng, RngCore};
-    use tinyvec::ArrayVec;
 
-    pub fn gen_random_seed<H: HashChain>() -> Seed {
-        let mut seed = ArrayVec::from_array_len([0u8; MAX_SEED_LEN], H::OUTPUT_SIZE as usize);
+    pub fn gen_random_seed<H: HashChain>() -> Seed<H> {
+        let mut seed = Seed::default();
         OsRng.fill_bytes(seed.as_mut_slice());
         seed
     }

--- a/tests/rfc_testcase1.rs
+++ b/tests/rfc_testcase1.rs
@@ -1,10 +1,10 @@
-use hbs_lms::Sha256;
+use hbs_lms::Sha256_256;
 
 // This file is testing our implementation against the first testcase of the RFC
 
 #[test]
 fn test() {
-    assert!(hbs_lms::verify::<Sha256>(MESSAGE, SIGNATURE, PUBLIC_KEY).is_ok());
+    assert!(hbs_lms::verify::<Sha256_256>(MESSAGE, SIGNATURE, PUBLIC_KEY).is_ok());
 }
 
 static PUBLIC_KEY: &[u8] = &[

--- a/tests/rfc_testcase2.rs
+++ b/tests/rfc_testcase2.rs
@@ -1,8 +1,8 @@
-use hbs_lms::Sha256;
+use hbs_lms::Sha256_256;
 
 #[test]
 fn test() {
-    assert!(hbs_lms::verify::<Sha256>(MESSAGE, SIGNATURE, PUBLIC_KEY).is_ok());
+    assert!(hbs_lms::verify::<Sha256_256>(MESSAGE, SIGNATURE, PUBLIC_KEY).is_ok());
 }
 
 static PUBLIC_KEY: &[u8] = &[


### PR DESCRIPTION
The changes allow the support of shorter hashes, such as 24-byte and 16-byte long truncated hashes.

The semantic equivalence to the reference implementation has not been proven yet, since the reference implementation does not implement shorter hash function support, yet.