### PR TITLE
Better Windows support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["cryptography", "no-std"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tinyvec = { version = "1.5.1", features = ["rustc_1_55"] }
+tinyvec = { version = "1.5.1", features = ["rustc_1_55", "alloc"] }
 subtle = { version = "2.4.1", default-features = false }
 signature = { version = "1.4.0", default-features = false }
 digest = { version = "0.10.2", default-features = false }

--- a/examples/lms-demo.rs
+++ b/examples/lms-demo.rs
@@ -292,13 +292,13 @@ fn genkey(args: &ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
     let seed: Seed<Hasher> = if let Some(seed) = args.value_of(SEED_PARAMETER) {
         let decoded = hex::decode(seed)?;
         if decoded.len() < Hasher::OUTPUT_SIZE as usize {
-            return DemoError::raise("Seed is too short");
+            return DemoError::raise("Seed (--seed) is too short. Needs to be 64 hexadecimal characters.");
         }
         let mut seed = Seed::default();
         seed.as_mut_slice().copy_from_slice(&decoded[..]);
         seed
     } else {
-        return DemoError::raise("Seed was not given");
+        return DemoError::raise("Seed (--seed) was not given. Needs to be 64 hexadecimal characters.");
     };
 
     let mut aux_data = vec![0u8; genkey_parameter.aux_data];

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,5 +1,5 @@
 use core::mem::size_of;
-use tinyvec::ArrayVec;
+use tinyvec::TinyVec;
 
 include!(concat!(env!("OUT_DIR"), "/constants.rs"));
 
@@ -12,7 +12,7 @@ pub type LmsLeafIdentifier = [u8; 4];
 type FvcMax = u16;
 type FvcSum = u16;
 type FvcCoef = (usize, u16, u64); // (index, shift, mask)
-pub type FastVerifyCached = (FvcMax, FvcSum, ArrayVec<[FvcCoef; MAX_HASH_CHAIN_COUNT]>);
+pub type FastVerifyCached = (FvcMax, FvcSum, TinyVec<[FvcCoef; MAX_HASH_CHAIN_COUNT]>);
 
 pub const D_PBLC: [u8; 2] = [0x80, 0x80];
 pub const D_MESG: [u8; 2] = [0x81, 0x81];

--- a/src/hasher/sha256.rs
+++ b/src/hasher/sha256.rs
@@ -1,5 +1,5 @@
 use core::convert::TryFrom;
-use tinyvec::ArrayVec;
+use tinyvec::TinyVec;
 
 use sha2::{
     digest::{typenum::U32, FixedOutput, FixedOutputReset, Output, OutputSizeUser, Reset, Update},
@@ -24,13 +24,13 @@ macro_rules! define_sha {
             const OUTPUT_SIZE: u16 = $output_size;
             const BLOCK_SIZE: u16 = 64;
 
-            fn finalize(self) -> ArrayVec<[u8; MAX_HASH_SIZE]> {
-                ArrayVec::try_from(&self.hasher.finalize_fixed()[..(Self::OUTPUT_SIZE as usize)])
+            fn finalize(self) -> TinyVec<[u8; MAX_HASH_SIZE]> {
+                TinyVec::try_from(&self.hasher.finalize_fixed()[..(Self::OUTPUT_SIZE as usize)])
                     .unwrap()
             }
 
-            fn finalize_reset(&mut self) -> ArrayVec<[u8; MAX_HASH_SIZE]> {
-                ArrayVec::try_from(
+            fn finalize_reset(&mut self) -> TinyVec<[u8; MAX_HASH_SIZE]> {
+                TinyVec::try_from(
                     &self.hasher.finalize_fixed_reset()[..(Self::OUTPUT_SIZE as usize)],
                 )
                 .unwrap()

--- a/src/hasher/shake256.rs
+++ b/src/hasher/shake256.rs
@@ -1,4 +1,4 @@
-use tinyvec::ArrayVec;
+use tinyvec::TinyVec;
 
 use sha3::{
     digest::{
@@ -26,16 +26,16 @@ macro_rules! define_shake {
             const OUTPUT_SIZE: u16 = $output_size;
             const BLOCK_SIZE: u16 = 64;
 
-            fn finalize(self) -> ArrayVec<[u8; MAX_HASH_SIZE]> {
+            fn finalize(self) -> TinyVec<[u8; MAX_HASH_SIZE]> {
                 let mut digest = [0u8; MAX_HASH_SIZE];
                 self.hasher.finalize_xof().read(&mut digest);
-                ArrayVec::from_array_len(digest, Self::OUTPUT_SIZE as usize)
+                TinyVec::from_array_len(digest, Self::OUTPUT_SIZE as usize)
             }
 
-            fn finalize_reset(&mut self) -> ArrayVec<[u8; MAX_HASH_SIZE]> {
+            fn finalize_reset(&mut self) -> TinyVec<[u8; MAX_HASH_SIZE]> {
                 let mut digest = [0u8; MAX_HASH_SIZE];
                 self.hasher.finalize_xof_reset().read(&mut digest);
-                ArrayVec::from_array_len(digest, Self::OUTPUT_SIZE as usize)
+                TinyVec::from_array_len(digest, Self::OUTPUT_SIZE as usize)
             }
         }
 

--- a/src/hss/definitions.rs
+++ b/src/hss/definitions.rs
@@ -1,11 +1,10 @@
 use core::convert::TryInto;
-
-use tinyvec::ArrayVec;
+use tinyvec::TinyVec;
 
 use crate::{
     constants::{MAX_ALLOWED_HSS_LEVELS, MAX_HSS_PUBLIC_KEY_LENGTH},
     hasher::HashChain,
-    hss::aux::{
+    hss::hss_aux::{
         hss_expand_aux_data, hss_finalize_aux_data, hss_optimal_aux_level, hss_store_aux_marker,
     },
     lms::{
@@ -16,10 +15,10 @@ use crate::{
     },
     util::helper::read_and_advance,
 };
-use crate::{hss::aux::hss_get_aux_data_len, lms::signing::LmsSignature};
+use crate::{hss::hss_aux::hss_get_aux_data_len, lms::signing::LmsSignature};
 
 use super::{
-    aux::{hss_is_aux_data_used, MutableExpandedAuxData},
+    hss_aux::{hss_is_aux_data_used, MutableExpandedAuxData},
     reference_impl_private_key::{
         generate_child_seed_and_lms_tree_identifier, generate_signature_randomizer,
         ReferenceImplPrivateKey,
@@ -28,9 +27,9 @@ use super::{
 
 #[derive(Debug, Default, PartialEq)]
 pub struct HssPrivateKey<H: HashChain> {
-    pub private_key: ArrayVec<[LmsPrivateKey<H>; MAX_ALLOWED_HSS_LEVELS]>,
-    pub public_key: ArrayVec<[LmsPublicKey<H>; MAX_ALLOWED_HSS_LEVELS - 1]>,
-    pub signatures: ArrayVec<[LmsSignature<H>; MAX_ALLOWED_HSS_LEVELS - 1]>, // Only L - 1 signatures needed
+    pub private_key: TinyVec<[LmsPrivateKey<H>; MAX_ALLOWED_HSS_LEVELS]>,
+    pub public_key: TinyVec<[LmsPublicKey<H>; MAX_ALLOWED_HSS_LEVELS - 1]>,
+    pub signatures: TinyVec<[LmsSignature<H>; MAX_ALLOWED_HSS_LEVELS - 1]>, // Only L - 1 signatures needed
 }
 
 impl<H: HashChain> HssPrivateKey<H> {
@@ -49,7 +48,7 @@ impl<H: HashChain> HssPrivateKey<H> {
         let used_leafs_indexes = private_key.compressed_used_leafs_indexes.to(&parameters);
 
         let lms_private_key = LmsPrivateKey {
-            seed: current_seed.seed,
+            seed: current_seed.seed.clone(),
             lms_tree_identifier: current_seed.lms_tree_identifier,
             lmots_parameter: *parameters[0].get_lmots_parameter(),
             lms_parameter: *parameters[0].get_lms_parameter(),
@@ -112,7 +111,7 @@ impl<H: HashChain> HssPrivateKey<H> {
 
     pub fn get_lifetime(&self) -> u64 {
         let mut lifetime: u64 = 0;
-        let mut trees_total_lmots_keys: ArrayVec<[u64; MAX_ALLOWED_HSS_LEVELS]> = ArrayVec::new();
+        let mut trees_total_lmots_keys: TinyVec<[u64; MAX_ALLOWED_HSS_LEVELS]> = TinyVec::new();
 
         for lms_private_key in (&self.private_key).into_iter().rev() {
             let total_lmots_keys = lms_private_key.lms_parameter.number_of_lm_ots_keys() as u64;
@@ -195,8 +194,8 @@ impl<H: HashChain> HssPublicKey<H> {
             level: levels,
         })
     }
-    pub fn to_binary_representation(&self) -> ArrayVec<[u8; MAX_HSS_PUBLIC_KEY_LENGTH]> {
-        let mut result = ArrayVec::new();
+    pub fn to_binary_representation(&self) -> TinyVec<[u8; MAX_HSS_PUBLIC_KEY_LENGTH]> {
+        let mut result = TinyVec::new();
 
         result.extend_from_slice(&(self.level as u32).to_be_bytes());
         result.extend_from_slice(self.public_key.to_binary_representation().as_slice());

--- a/src/hss/seed_derive.rs
+++ b/src/hss/seed_derive.rs
@@ -1,4 +1,4 @@
-use tinyvec::ArrayVec;
+use tinyvec::TinyVec;
 
 use crate::{
     constants::{
@@ -34,7 +34,7 @@ impl<'a, H: HashChain> SeedDerive<'a, H> {
         self.child_seed = seed;
     }
 
-    pub fn seed_derive(&mut self, increment_j: bool) -> ArrayVec<[u8; MAX_HASH_SIZE]> {
+    pub fn seed_derive(&mut self, increment_j: bool) -> TinyVec<[u8; MAX_HASH_SIZE]> {
         let mut buffer = [0u8; PRNG_MAX_LEN];
 
         buffer[PRNG_I..PRNG_I + ILEN].copy_from_slice(self.lms_tree_identifier);

--- a/src/hss/signing.rs
+++ b/src/hss/signing.rs
@@ -4,7 +4,7 @@ use crate::{
         MAX_HSS_SIGNATURE_LENGTH, MAX_HSS_SIGNED_PUBLIC_KEY_LENGTH,
     },
     hss::{
-        aux::MutableExpandedAuxData,
+        hss_aux::MutableExpandedAuxData,
         reference_impl_private_key::{generate_signature_randomizer, SeedAndLmsTreeIdentifier},
     },
     lms::{
@@ -19,12 +19,12 @@ use crate::{
 use super::definitions::HssPrivateKey;
 
 use core::convert::TryInto;
-use tinyvec::ArrayVec;
+use tinyvec::TinyVec;
 
 #[derive(PartialEq)]
 pub struct HssSignature<H: HashChain> {
     pub level: usize,
-    pub signed_public_keys: ArrayVec<[HssSignedPublicKey<H>; MAX_ALLOWED_HSS_LEVELS - 1]>,
+    pub signed_public_keys: TinyVec<[HssSignedPublicKey<H>; MAX_ALLOWED_HSS_LEVELS - 1]>,
     pub signature: LmsSignature<H>,
 }
 
@@ -50,7 +50,7 @@ impl<H: HashChain> HssSignature<H> {
         #[allow(unused_mut)]
         let mut signature_randomizer = generate_signature_randomizer::<H>(
             &SeedAndLmsTreeIdentifier {
-                seed: prv[max_level - 1].seed,
+                seed: prv[max_level - 1].seed.clone(),
                 lms_tree_identifier: prv[max_level - 1].lms_tree_identifier,
             },
             &prv[max_level - 1].used_leafs_index,
@@ -78,7 +78,7 @@ impl<H: HashChain> HssSignature<H> {
         sig.push(new_signature);
 
         // Create list of signed keys
-        let mut signed_public_keys = ArrayVec::new();
+        let mut signed_public_keys = TinyVec::new();
         for i in 0..max_level - 1 {
             signed_public_keys.push(HssSignedPublicKey::new(sig[i].clone(), public[i].clone()));
         }
@@ -90,8 +90,8 @@ impl<H: HashChain> HssSignature<H> {
         })
     }
 
-    pub fn to_binary_representation(&self) -> ArrayVec<[u8; MAX_HSS_SIGNATURE_LENGTH]> {
-        let mut result = ArrayVec::new();
+    pub fn to_binary_representation(&self) -> TinyVec<[u8; MAX_HSS_SIGNATURE_LENGTH]> {
+        let mut result = TinyVec::new();
 
         result.extend_from_slice(&(self.level as u32).to_be_bytes());
 
@@ -111,7 +111,7 @@ impl<H: HashChain> HssSignature<H> {
 pub struct InMemoryHssSignature<'a, H: HashChain> {
     pub level: usize,
     pub signed_public_keys:
-        ArrayVec<[Option<InMemoryHssSignedPublicKey<'a, H>>; MAX_ALLOWED_HSS_LEVELS - 1]>,
+        TinyVec<[Option<InMemoryHssSignedPublicKey<'a, H>>; MAX_ALLOWED_HSS_LEVELS - 1]>,
     pub signature: InMemoryLmsSignature<'a, H>,
 }
 
@@ -148,7 +148,7 @@ impl<'a, H: HashChain> InMemoryHssSignature<'a, H> {
         let level =
             u32::from_be_bytes(read_and_advance(data, 4, &mut index).try_into().unwrap()) as usize;
 
-        let mut signed_public_keys = ArrayVec::new();
+        let mut signed_public_keys = TinyVec::new();
 
         for _ in 0..level {
             let signed_public_key = InMemoryHssSignedPublicKey::<'a, H>::new(&data[index..])?;
@@ -195,8 +195,8 @@ impl<H: HashChain> HssSignedPublicKey<H> {
         }
     }
 
-    pub fn to_binary_representation(&self) -> ArrayVec<[u8; MAX_HSS_SIGNED_PUBLIC_KEY_LENGTH]> {
-        let mut result = ArrayVec::new();
+    pub fn to_binary_representation(&self) -> TinyVec<[u8; MAX_HSS_SIGNED_PUBLIC_KEY_LENGTH]> {
+        let mut result = TinyVec::new();
 
         result.extend_from_slice(self.sig.to_binary_representation().as_slice());
         result.extend_from_slice(self.public_key.to_binary_representation().as_slice());
@@ -264,7 +264,7 @@ mod tests {
     use crate::constants::LmsTreeIdentifier;
     use crate::util::helper::test_helper::gen_random_seed;
     use rand::{rngs::OsRng, RngCore};
-    use tinyvec::ArrayVec;
+    use tinyvec::TinyVec;
 
     type Hasher = Sha256_256;
 
@@ -306,9 +306,12 @@ mod tests {
         );
 
         let message = [3, 54, 32, 45, 67, 32, 12, 58, 29, 49];
+
         let mut signature_randomizer =
-            ArrayVec::from_array_len([0u8; 32], Hasher::OUTPUT_SIZE as usize);
+            TinyVec::from_array_len([0u8; 32], Hasher::OUTPUT_SIZE as usize);
+
         OsRng.fill_bytes(&mut signature_randomizer);
+
         let signature = LmsSignature::sign(
             &mut keypair.private_key,
             &message,

--- a/src/lm_ots/definitions.rs
+++ b/src/lm_ots/definitions.rs
@@ -1,4 +1,4 @@
-use tinyvec::ArrayVec;
+use tinyvec::TinyVec;
 
 use crate::{
     constants::{LmsLeafIdentifier, LmsTreeIdentifier, MAX_HASH_CHAIN_COUNT, MAX_HASH_SIZE},
@@ -11,7 +11,7 @@ use super::parameters::LmotsParameter;
 pub struct LmotsPrivateKey<H: HashChain> {
     pub lms_tree_identifier: LmsTreeIdentifier,
     pub lms_leaf_identifier: LmsLeafIdentifier,
-    pub key: ArrayVec<[ArrayVec<[u8; MAX_HASH_SIZE]>; MAX_HASH_CHAIN_COUNT]>, // [[0u8; n]; p];
+    pub key: TinyVec<[TinyVec<[u8; MAX_HASH_SIZE]>; MAX_HASH_CHAIN_COUNT]>, // [[0u8; n]; p];
     pub lmots_parameter: LmotsParameter<H>,
 }
 
@@ -19,7 +19,7 @@ impl<H: HashChain> LmotsPrivateKey<H> {
     pub fn new(
         lms_tree_identifier: LmsTreeIdentifier,
         lms_leaf_identifier: LmsLeafIdentifier,
-        key: ArrayVec<[ArrayVec<[u8; MAX_HASH_SIZE]>; MAX_HASH_CHAIN_COUNT]>,
+        key: TinyVec<[TinyVec<[u8; MAX_HASH_SIZE]>; MAX_HASH_CHAIN_COUNT]>,
         lmots_parameter: LmotsParameter<H>,
     ) -> Self {
         LmotsPrivateKey {
@@ -34,7 +34,7 @@ impl<H: HashChain> LmotsPrivateKey<H> {
 pub struct LmotsPublicKey<H: HashChain> {
     pub lms_tree_identifier: LmsTreeIdentifier,
     pub lms_leaf_identifier: LmsLeafIdentifier,
-    pub key: ArrayVec<[u8; MAX_HASH_SIZE]>,
+    pub key: TinyVec<[u8; MAX_HASH_SIZE]>,
     pub lmots_parameter: LmotsParameter<H>,
 }
 
@@ -42,7 +42,7 @@ impl<H: HashChain> LmotsPublicKey<H> {
     pub fn new(
         lms_tree_identifier: LmsTreeIdentifier,
         lms_leaf_identifier: LmsLeafIdentifier,
-        key: ArrayVec<[u8; MAX_HASH_SIZE]>,
+        key: TinyVec<[u8; MAX_HASH_SIZE]>,
         lmots_parameter: LmotsParameter<H>,
     ) -> Self {
         LmotsPublicKey {

--- a/src/lm_ots/keygen.rs
+++ b/src/lm_ots/keygen.rs
@@ -4,7 +4,7 @@ use crate::constants::*;
 use crate::constants::{D_PBLC, MAX_HASH_CHAIN_COUNT, MAX_HASH_SIZE};
 use crate::hasher::HashChain;
 use crate::Seed;
-use tinyvec::ArrayVec;
+use tinyvec::TinyVec;
 
 pub fn generate_private_key<H: HashChain>(
     lms_tree_identifier: LmsTreeIdentifier,
@@ -12,7 +12,7 @@ pub fn generate_private_key<H: HashChain>(
     seed: Seed<H>,
     lmots_parameter: LmotsParameter<H>,
 ) -> LmotsPrivateKey<H> {
-    let mut key = ArrayVec::new();
+    let mut key = TinyVec::new();
 
     let mut hasher = lmots_parameter.get_hasher();
 
@@ -41,8 +41,8 @@ pub fn generate_public_key<H: HashChain>(private_key: &LmotsPrivateKey<H>) -> Lm
     let hash_chain_count: usize = 2_usize.pow(lmots_parameter.get_winternitz() as u32) - 1;
     let key = &private_key.key;
 
-    let mut public_key_data: ArrayVec<[ArrayVec<[u8; MAX_HASH_SIZE]>; MAX_HASH_CHAIN_COUNT]> =
-        ArrayVec::new();
+    let mut public_key_data: TinyVec<[TinyVec<[u8; MAX_HASH_SIZE]>; MAX_HASH_CHAIN_COUNT]> =
+        TinyVec::new();
 
     for i in 0..lmots_parameter.get_hash_chain_count() as usize {
         let mut hash_chain_data = H::prepare_hash_chain_data(

--- a/src/lm_ots/parameters.rs
+++ b/src/lm_ots/parameters.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use tinyvec::ArrayVec;
+use tinyvec::TinyVec;
 
 use crate::constants::get_hash_chain_count;
 use crate::{
@@ -142,7 +142,7 @@ impl<H: HashChain> LmotsParameter<H> {
         let max_word_size = (1 << self.get_winternitz()) - 1;
         let sum = max * max_word_size;
 
-        let mut coef = ArrayVec::new();
+        let mut coef = TinyVec::new();
         for i in 0..self.get_hash_chain_count() {
             coef.push(coef_helper(i, self.get_winternitz()));
         }
@@ -191,8 +191,8 @@ impl<H: HashChain> LmotsParameter<H> {
         sum << self.get_checksum_left_shift()
     }
 
-    pub fn append_checksum_to(&self, byte_string: &[u8]) -> ArrayVec<[u8; MAX_HASH_SIZE + 2]> {
-        let mut result = ArrayVec::new();
+    pub fn append_checksum_to(&self, byte_string: &[u8]) -> TinyVec<[u8; MAX_HASH_SIZE + 2]> {
+        let mut result = TinyVec::new();
 
         let checksum = self.checksum(byte_string);
 

--- a/src/lm_ots/signing.rs
+++ b/src/lm_ots/signing.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 use core::convert::TryInto;
-use tinyvec::ArrayVec;
+use tinyvec::TinyVec;
 
 #[cfg(feature = "fast_verify")]
 use {
@@ -23,8 +23,8 @@ use super::parameters::LmotsParameter;
 
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct LmotsSignature<H: HashChain> {
-    pub signature_randomizer: ArrayVec<[u8; MAX_HASH_SIZE]>,
-    pub signature_data: ArrayVec<[ArrayVec<[u8; MAX_HASH_SIZE]>; MAX_HASH_CHAIN_COUNT]>,
+    pub signature_randomizer: TinyVec<[u8; MAX_HASH_SIZE]>,
+    pub signature_data: TinyVec<[TinyVec<[u8; MAX_HASH_SIZE]>; MAX_HASH_CHAIN_COUNT]>,
     pub lmots_parameter: LmotsParameter<H>,
     pub hash_iterations: u16,
 }
@@ -62,7 +62,7 @@ impl<'a, H: HashChain> PartialEq<LmotsSignature<H>> for InMemoryLmotsSignature<'
 impl<H: HashChain> LmotsSignature<H> {
     fn calculate_message_hash(
         private_key: &LmotsPrivateKey<H>,
-        signature_randomizer: &ArrayVec<[u8; MAX_HASH_SIZE]>,
+        signature_randomizer: &TinyVec<[u8; MAX_HASH_SIZE]>,
         message: &[u8],
     ) -> H {
         let lmots_parameter = private_key.lmots_parameter;
@@ -79,7 +79,7 @@ impl<H: HashChain> LmotsSignature<H> {
     #[cfg(feature = "fast_verify")]
     fn calculate_message_hash_fast_verify(
         private_key: &LmotsPrivateKey<H>,
-        signature_randomizer: &mut ArrayVec<[u8; MAX_HASH_SIZE]>,
+        signature_randomizer: &mut TinyVec<[u8; MAX_HASH_SIZE]>,
         message: Option<&[u8]>,
         message_mut: Option<&mut [u8]>,
     ) -> H {
@@ -112,13 +112,13 @@ impl<H: HashChain> LmotsSignature<H> {
 
     fn calculate_signature(
         private_key: &LmotsPrivateKey<H>,
-        message_hash_with_checksum: &ArrayVec<[u8; MAX_HASH_SIZE + 2]>,
-    ) -> ArrayVec<[ArrayVec<[u8; MAX_HASH_SIZE]>; MAX_HASH_CHAIN_COUNT]> {
+        message_hash_with_checksum: &TinyVec<[u8; MAX_HASH_SIZE + 2]>,
+    ) -> TinyVec<[TinyVec<[u8; MAX_HASH_SIZE]>; MAX_HASH_CHAIN_COUNT]> {
         let lmots_parameter = private_key.lmots_parameter;
 
         let mut hasher = lmots_parameter.get_hasher();
 
-        let mut signature_data = ArrayVec::new();
+        let mut signature_data = TinyVec::new();
 
         for i in 0..lmots_parameter.get_hash_chain_count() {
             let a = coef(
@@ -126,7 +126,7 @@ impl<H: HashChain> LmotsSignature<H> {
                 i,
                 lmots_parameter.get_winternitz(),
             ) as usize;
-            let initial = private_key.key[i as usize];
+            let initial = private_key.key[i as usize].clone();
             let mut hash_chain_data = H::prepare_hash_chain_data(
                 &private_key.lms_tree_identifier,
                 &private_key.lms_leaf_identifier,
@@ -141,7 +141,7 @@ impl<H: HashChain> LmotsSignature<H> {
 
     pub fn sign(
         private_key: &LmotsPrivateKey<H>,
-        signature_randomizer: &ArrayVec<[u8; MAX_HASH_SIZE]>,
+        signature_randomizer: &TinyVec<[u8; MAX_HASH_SIZE]>,
         message: &[u8],
     ) -> Self {
         let mut hasher =
@@ -152,7 +152,7 @@ impl<H: HashChain> LmotsSignature<H> {
     #[cfg(feature = "fast_verify")]
     pub fn sign_fast_verify(
         private_key: &LmotsPrivateKey<H>,
-        signature_randomizer: &mut ArrayVec<[u8; MAX_HASH_SIZE]>,
+        signature_randomizer: &mut TinyVec<[u8; MAX_HASH_SIZE]>,
         message: Option<&[u8]>,
         message_mut: Option<&mut [u8]>,
     ) -> Self {
@@ -168,11 +168,11 @@ impl<H: HashChain> LmotsSignature<H> {
     fn sign_core(
         private_key: &LmotsPrivateKey<H>,
         hasher: &mut H,
-        signature_randomizer: &ArrayVec<[u8; MAX_HASH_SIZE]>,
+        signature_randomizer: &TinyVec<[u8; MAX_HASH_SIZE]>,
     ) -> Self {
         let lmots_parameter = private_key.lmots_parameter;
 
-        let message_hash: ArrayVec<[u8; MAX_HASH_SIZE]> = hasher.finalize_reset();
+        let message_hash: TinyVec<[u8; MAX_HASH_SIZE]> = hasher.finalize_reset();
         let message_hash_with_checksum =
             lmots_parameter.append_checksum_to(message_hash.as_slice());
 
@@ -188,15 +188,15 @@ impl<H: HashChain> LmotsSignature<H> {
         });
 
         LmotsSignature {
-            signature_randomizer: *signature_randomizer,
+            signature_randomizer: signature_randomizer.clone(),
             signature_data,
             lmots_parameter,
             hash_iterations,
         }
     }
 
-    pub fn to_binary_representation(&self) -> ArrayVec<[u8; MAX_LMOTS_SIGNATURE_LENGTH]> {
-        let mut result = ArrayVec::new();
+    pub fn to_binary_representation(&self) -> TinyVec<[u8; MAX_LMOTS_SIGNATURE_LENGTH]> {
+        let mut result = TinyVec::new();
 
         result.extend_from_slice(&(self.lmots_parameter.get_type_id()).to_be_bytes());
         assert_eq!(
@@ -255,10 +255,10 @@ fn optimize_message_hash<H: HashChain>(
     message: Option<&[u8]>,
 ) {
     let message = message
-        .map(|message: &[u8]| ArrayVec::try_from(message).unwrap())
+        .map(|message: &[u8]| TinyVec::try_from(message).unwrap())
         .unwrap_or_default();
 
-    assert_eq!(message, ArrayVec::new());
+    assert_eq!(message, TinyVec::new());
     let fast_verify_cached = lmots_parameter.fast_verify_eval_init();
 
     let rx = {
@@ -296,12 +296,12 @@ fn thread_optimize_message_hash<H: HashChain>(
     hasher: &H,
     lmots_parameter: &LmotsParameter<H>,
     fast_verify_cached: &FastVerifyCached,
-    message: &ArrayVec<[u8; MAX_LMS_PUBLIC_KEY_LENGTH]>,
-) -> (u16, ArrayVec<[u8; MAX_HASH_SIZE]>) {
+    message: &TinyVec<[u8; MAX_LMS_PUBLIC_KEY_LENGTH]>,
+) -> (u16, TinyVec<[u8; MAX_HASH_SIZE]>) {
     let mut max_hash_iterations = 0;
 
-    let mut trial_randomizer: ArrayVec<[u8; MAX_HASH_SIZE]> = ArrayVec::new();
-    let mut randomizer: ArrayVec<[u8; MAX_HASH_SIZE]> = ArrayVec::new();
+    let mut trial_randomizer: TinyVec<[u8; MAX_HASH_SIZE]> = TinyVec::new();
+    let mut randomizer: TinyVec<[u8; MAX_HASH_SIZE]> = TinyVec::new();
 
     for _ in 0..lmots_parameter.get_hash_function_output_size() {
         trial_randomizer.push(0u8);
@@ -316,7 +316,7 @@ fn thread_optimize_message_hash<H: HashChain>(
             .chain(&trial_randomizer)
             .finalize();
 
-        let message_hash: ArrayVec<[u8; MAX_HASH_SIZE]> = hasher
+        let message_hash: TinyVec<[u8; MAX_HASH_SIZE]> = hasher
             .clone()
             .chain(trial_randomizer.as_slice())
             .chain(message)
@@ -335,7 +335,7 @@ fn thread_optimize_message_hash<H: HashChain>(
 
 #[cfg(test)]
 mod tests {
-    use tinyvec::ArrayVec;
+    use tinyvec::TinyVec;
 
     use crate::{
         constants::{MAX_HASH_CHAIN_COUNT, MAX_HASH_SIZE},
@@ -354,17 +354,17 @@ mod tests {
             fn $name() {
                 let lmots_parameter = LmotsAlgorithm::construct_default_parameter::<$hash_chain>();
 
-                let mut signature_randomizer = ArrayVec::new();
-                let mut signature_data: ArrayVec<
-                    [ArrayVec<[u8; MAX_HASH_SIZE]>; MAX_HASH_CHAIN_COUNT],
-                > = ArrayVec::new();
+                let mut signature_randomizer = TinyVec::new();
+                let mut signature_data: TinyVec<
+                    [TinyVec<[u8; MAX_HASH_SIZE]>; MAX_HASH_CHAIN_COUNT],
+                > = TinyVec::new();
 
                 for i in 0..lmots_parameter.get_hash_function_output_size() as usize {
                     signature_randomizer.push(i as u8);
                 }
 
                 for i in 0..lmots_parameter.get_hash_chain_count() as usize {
-                    signature_data.push(ArrayVec::new());
+                    signature_data.push(TinyVec::new());
                     for j in 0..lmots_parameter.get_hash_function_output_size() as usize {
                         signature_data[i].push(j as u8);
                     }

--- a/src/lms/definitions.rs
+++ b/src/lms/definitions.rs
@@ -9,11 +9,11 @@ use crate::util::helper::read_and_advance;
 use crate::{lm_ots, Seed};
 
 use core::convert::TryInto;
-use tinyvec::ArrayVec;
+use tinyvec::TinyVec;
 
 use super::parameters::LmsParameter;
 
-#[derive(Debug, Default, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct LmsPrivateKey<H: HashChain> {
     pub lms_tree_identifier: LmsTreeIdentifier,
     pub used_leafs_index: u32,
@@ -49,7 +49,7 @@ impl<H: HashChain> LmsPrivateKey<H> {
         let key = lm_ots::keygen::generate_private_key(
             self.lms_tree_identifier,
             self.used_leafs_index.to_be_bytes(),
-            self.seed,
+            self.seed.clone(),
             self.lmots_parameter,
         );
         self.used_leafs_index += 1;
@@ -60,7 +60,7 @@ impl<H: HashChain> LmsPrivateKey<H> {
 
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct LmsPublicKey<H: HashChain> {
-    pub key: ArrayVec<[u8; MAX_HASH_SIZE]>,
+    pub key: TinyVec<[u8; MAX_HASH_SIZE]>,
     pub lms_tree_identifier: LmsTreeIdentifier,
     pub lmots_parameter: LmotsParameter<H>,
     pub lms_parameter: LmsParameter<H>,
@@ -81,8 +81,8 @@ impl<H: HashChain> LmsPublicKey<H> {
         }
     }
 
-    pub fn to_binary_representation(&self) -> ArrayVec<[u8; MAX_LMS_PUBLIC_KEY_LENGTH]> {
-        let mut result = ArrayVec::new();
+    pub fn to_binary_representation(&self) -> TinyVec<[u8; MAX_LMS_PUBLIC_KEY_LENGTH]> {
+        let mut result = TinyVec::new();
 
         result.extend_from_slice(&self.lms_parameter.get_type_id().to_be_bytes());
         result.extend_from_slice(&self.lmots_parameter.get_type_id().to_be_bytes());

--- a/src/lms/helper.rs
+++ b/src/lms/helper.rs
@@ -1,8 +1,8 @@
-use tinyvec::ArrayVec;
+use tinyvec::TinyVec;
 
 use crate::constants::{D_INTR, D_LEAF, MAX_HASH_SIZE};
 use crate::hasher::HashChain;
-use crate::hss::aux::{hss_extract_aux_data, hss_save_aux_data, MutableExpandedAuxData};
+use crate::hss::hss_aux::{hss_extract_aux_data, hss_save_aux_data, MutableExpandedAuxData};
 use crate::lm_ots;
 
 use super::definitions::LmsPrivateKey;
@@ -11,7 +11,7 @@ pub fn get_tree_element<H: HashChain>(
     index: usize,
     private_key: &LmsPrivateKey<H>,
     aux_data: &mut Option<MutableExpandedAuxData>,
-) -> ArrayVec<[u8; MAX_HASH_SIZE]> {
+) -> TinyVec<[u8; MAX_HASH_SIZE]> {
     // Check if we already have the value cached
     if let Some(aux_data) = aux_data {
         if let Some(result) = hss_extract_aux_data::<H>(aux_data, index) {
@@ -29,7 +29,7 @@ pub fn get_tree_element<H: HashChain>(
         let lms_ots_private_key = lm_ots::keygen::generate_private_key(
             private_key.lms_tree_identifier,
             ((index - max_private_keys) as u32).to_be_bytes(),
-            private_key.seed,
+            private_key.seed.clone(),
             private_key.lmots_parameter,
         );
         let lm_ots_public_key = lm_ots::keygen::generate_public_key(&lms_ots_private_key);

--- a/src/lms/mod.rs
+++ b/src/lms/mod.rs
@@ -1,5 +1,5 @@
 use crate::hasher::HashChain;
-use crate::hss::aux::MutableExpandedAuxData;
+use crate::hss::hss_aux::MutableExpandedAuxData;
 use crate::hss::parameter::HssParameter;
 use crate::hss::reference_impl_private_key::SeedAndLmsTreeIdentifier;
 use crate::lms::definitions::LmsPrivateKey;
@@ -26,7 +26,7 @@ pub fn generate_key_pair<H: HashChain>(
     let lms_parameter = parameter.get_lms_parameter();
 
     let private_key = LmsPrivateKey::new(
-        seed.seed,
+        seed.seed.clone(),
         seed.lms_tree_identifier,
         *used_leafs_index,
         *lmots_parameter,

--- a/src/lms/signing.rs
+++ b/src/lms/signing.rs
@@ -2,7 +2,7 @@ use crate::constants::{
     LmsLeafIdentifier, MAX_HASH_SIZE, MAX_LMS_SIGNATURE_LENGTH, MAX_TREE_HEIGHT,
 };
 use crate::hasher::HashChain;
-use crate::hss::aux::MutableExpandedAuxData;
+use crate::hss::hss_aux::MutableExpandedAuxData;
 use crate::lm_ots;
 use crate::lm_ots::definitions::LmotsPrivateKey;
 use crate::lm_ots::parameters::LmotsAlgorithm;
@@ -13,7 +13,7 @@ use crate::lms::parameters::LmsAlgorithm;
 use crate::util::helper::{read, read_and_advance};
 
 use core::convert::TryInto;
-use tinyvec::ArrayVec;
+use tinyvec::TinyVec;
 
 use super::helper::get_tree_element;
 use super::parameters::LmsParameter;
@@ -22,7 +22,7 @@ use super::parameters::LmsParameter;
 pub struct LmsSignature<H: HashChain> {
     pub lms_leaf_identifier: LmsLeafIdentifier,
     pub lmots_signature: LmotsSignature<H>,
-    pub authentication_path: ArrayVec<[ArrayVec<[u8; MAX_HASH_SIZE]>; MAX_TREE_HEIGHT]>,
+    pub authentication_path: TinyVec<[TinyVec<[u8; MAX_HASH_SIZE]>; MAX_TREE_HEIGHT]>,
     pub lms_parameter: LmsParameter<H>,
 }
 
@@ -65,12 +65,12 @@ impl<H: HashChain> LmsSignature<H> {
         lms_private_key: &mut LmsPrivateKey<H>,
         lm_ots_private_key: &LmotsPrivateKey<H>,
         aux_data: &mut Option<MutableExpandedAuxData>,
-    ) -> Result<ArrayVec<[ArrayVec<[u8; MAX_HASH_SIZE]>; MAX_TREE_HEIGHT]>, ()> {
+    ) -> Result<TinyVec<[TinyVec<[u8; MAX_HASH_SIZE]>; MAX_TREE_HEIGHT]>, ()> {
         let tree_height = lms_private_key.lms_parameter.get_tree_height();
         let signature_leaf_index = 2usize.pow(tree_height as u32)
             + u32::from_be_bytes(lm_ots_private_key.lms_leaf_identifier) as usize;
 
-        let mut authentication_path = ArrayVec::new();
+        let mut authentication_path = TinyVec::new();
 
         for i in 0..tree_height.into() {
             let tree_index = (signature_leaf_index / (2usize.pow(i as u32))) ^ 0x1;
@@ -85,7 +85,7 @@ impl<H: HashChain> LmsSignature<H> {
         lms_private_key: &mut LmsPrivateKey<H>,
         message: Option<&[u8]>,
         message_mut: Option<&mut [u8]>,
-        signature_randomizer: &mut ArrayVec<[u8; MAX_HASH_SIZE]>,
+        signature_randomizer: &mut TinyVec<[u8; MAX_HASH_SIZE]>,
         aux_data: &mut Option<MutableExpandedAuxData>,
     ) -> Result<LmsSignature<H>, ()> {
         let lm_ots_private_key = lms_private_key.use_lmots_private_key()?;
@@ -116,7 +116,7 @@ impl<H: HashChain> LmsSignature<H> {
     pub fn sign(
         lms_private_key: &mut LmsPrivateKey<H>,
         message: &[u8],
-        signature_randomizer: &ArrayVec<[u8; MAX_HASH_SIZE]>,
+        signature_randomizer: &TinyVec<[u8; MAX_HASH_SIZE]>,
         aux_data: &mut Option<MutableExpandedAuxData>,
     ) -> Result<LmsSignature<H>, ()> {
         let lm_ots_private_key = lms_private_key.use_lmots_private_key()?;
@@ -140,8 +140,8 @@ impl<H: HashChain> LmsSignature<H> {
         Ok(signature)
     }
 
-    pub fn to_binary_representation(&self) -> ArrayVec<[u8; MAX_LMS_SIGNATURE_LENGTH]> {
-        let mut result = ArrayVec::new();
+    pub fn to_binary_representation(&self) -> TinyVec<[u8; MAX_LMS_SIGNATURE_LENGTH]> {
+        let mut result = TinyVec::new();
 
         result.extend_from_slice(&self.lms_leaf_identifier);
 
@@ -221,7 +221,7 @@ mod tests {
     use super::LmsSignature;
 
     use rand::{rngs::OsRng, RngCore};
-    use tinyvec::ArrayVec;
+    use tinyvec::TinyVec;
 
     #[test]
     fn test_binary_representation_of_signature() {
@@ -236,7 +236,7 @@ mod tests {
         );
 
         let message = "Hi, what up?".as_bytes();
-        let mut signature_randomizer = ArrayVec::from([0u8; 32]);
+        let mut signature_randomizer = TinyVec::from([0u8; 32]);
         OsRng.fill_bytes(&mut signature_randomizer);
 
         let signature =

--- a/src/lms/verify.rs
+++ b/src/lms/verify.rs
@@ -1,4 +1,4 @@
-use tinyvec::ArrayVec;
+use tinyvec::TinyVec;
 
 use crate::constants::{D_INTR, D_LEAF, MAX_HASH_SIZE};
 use crate::hasher::HashChain;
@@ -32,7 +32,7 @@ fn generate_public_key_candiate<'a, H: HashChain>(
     signature: &InMemoryLmsSignature<'a, H>,
     public_key: &InMemoryLmsPublicKey<'a, H>,
     message: &[u8],
-) -> Result<ArrayVec<[u8; MAX_HASH_SIZE]>, ()> {
+) -> Result<TinyVec<[u8; MAX_HASH_SIZE]>, ()> {
     let leafs = signature.lms_parameter.number_of_lm_ots_keys() as u32;
 
     let curr = signature.lms_leaf_identifier;
@@ -94,7 +94,7 @@ mod tests {
     };
 
     use rand::{rngs::OsRng, RngCore};
-    use tinyvec::ArrayVec;
+    use tinyvec::TinyVec;
 
     #[test]
     fn test_verification() {
@@ -116,7 +116,7 @@ mod tests {
 
         let mut first_message = [0u8, 4, 2, 7, 4, 2, 58, 3, 69, 3];
         let mut second_message = [1u8, 2, 3, 4, 5, 6, 7, 0];
-        let mut signature_randomizer = ArrayVec::from([0u8; 32]);
+        let mut signature_randomizer = TinyVec::from([0u8; 32]);
         OsRng.fill_bytes(&mut signature_randomizer);
 
         let first_signature = LmsSignature::sign(


### PR DESCRIPTION
In this PR:
1. Changed ArrayVec to TinyVec to prevent stack overflows (on Windows?).
2. Changed src/hss/aux.rs to src/hss/hss_aux.rs so that the file can be created on Windows. (https://stackoverflow.com/a/67226358/13819662)
3. Added better error message for "seed to short" in the example.