### PR TITLE
Dist state mgmt

### DIFF
--- a/.github/actions/cross-tests/action.yml
+++ b/.github/actions/cross-tests/action.yml
@@ -14,12 +14,10 @@ runs:
   using: "composite"
   steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: ${{ inputs.rust }}
-          target: ${{ inputs.target }}
-          override: true
+          targets: ${{ inputs.target }}
       - uses: RustCrypto/actions/cross-install@master
       - run: |
           # cd ${{ inputs.package }} Not needed, as only a single crate is located in this repository

--- a/.github/actions/cross-tests/action.yml
+++ b/.github/actions/cross-tests/action.yml
@@ -13,7 +13,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/lms.yml
+++ b/.github/workflows/lms.yml
@@ -17,12 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
           components: rustfmt
-          profile: minimal
-          override: true
       - run: |
           cargo fmt --version
           cargo fmt --all -- --check
@@ -32,12 +30,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
           components: clippy
-          profile: minimal
-          override: true
       - run: |
           cargo clippy --version
           cargo clippy --lib --bins --tests --examples --all-features -- -D warnings
@@ -86,12 +82,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          target: ${{ matrix.target }}
-          override: true
+          targets: ${{ matrix.target }}
       - run: cargo build --no-default-features --target ${{ matrix.target }}
 
   test:
@@ -105,11 +99,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
       - run: cargo test
       - run: cargo test -- --include-ignored
       - run: cargo test --features fast_verify
@@ -121,9 +113,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: RustCrypto/actions/cargo-cache@master
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: nightly
       - run: rustup run nightly cargo bench
 

--- a/.github/workflows/lms.yml
+++ b/.github/workflows/lms.yml
@@ -137,7 +137,6 @@ jobs:
           - stable
         target:
           - aarch64-unknown-linux-gnu
-          - mips-unknown-linux-gnu
         features:
           - default
 

--- a/.github/workflows/lms.yml
+++ b/.github/workflows/lms.yml
@@ -15,7 +15,7 @@ jobs:
   rustfmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: RustCrypto/actions/cargo-cache@master
       - uses: actions-rs/toolchain@v1
         with:
@@ -30,7 +30,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: RustCrypto/actions/cargo-cache@master
       - uses: actions-rs/toolchain@v1
         with:
@@ -45,7 +45,7 @@ jobs:
   check-for-todos:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: make check-for-todos
         continue-on-error: true
 
@@ -54,7 +54,7 @@ jobs:
     outputs:
       msrv: ${{ steps.msrv.outputs.msrv }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: RustCrypto/actions/cargo-cache@master
       - name: Install msrv
         run: cargo install cargo-msrv
@@ -68,9 +68,9 @@ jobs:
     outputs:
       msrv: ${{ steps.msrv.outputs.msrv }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - id: msrv
-        run: echo "msrv::$(grep rust-version Cargo.toml | cut -d'"' -f2-2)" >> $GITHUB_OUTPUT
+        run: echo "::set-output name=msrv::$(grep rust-version Cargo.toml | cut -d'"' -f2-2)"
 
   build:
     needs: set-msrv
@@ -84,7 +84,7 @@ jobs:
           - thumbv7em-none-eabi
           - wasm32-unknown-unknown
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: RustCrypto/actions/cargo-cache@master
       - uses: actions-rs/toolchain@v1
         with:
@@ -103,7 +103,7 @@ jobs:
           - ${{needs.set-msrv.outputs.msrv}}
           - stable
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: RustCrypto/actions/cargo-cache@master
       - uses: actions-rs/toolchain@v1
         with:
@@ -119,7 +119,7 @@ jobs:
     needs: set-msrv
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: RustCrypto/actions/cargo-cache@master
       - uses: actions-rs/toolchain@v1
         with:
@@ -146,7 +146,7 @@ jobs:
       # Cross mounts only current package, i.e. by default it ignores workspace's Cargo.toml
         working-directory: .
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/cross-tests
         with:
           rust: ${{ matrix.rust }}

--- a/.github/workflows/lms.yml
+++ b/.github/workflows/lms.yml
@@ -70,7 +70,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - id: msrv
-        run: echo "::set-output name=msrv::$(grep rust-version Cargo.toml | cut -d'"' -f2-2)"
+        run: echo "msrv::$(grep rust-version Cargo.toml | cut -d'"' -f2-2)" >> $GITHUB_OUTPUT
 
   build:
     needs: set-msrv

--- a/.github/workflows/lms.yml
+++ b/.github/workflows/lms.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [ master ]
   push:
-    branches: [ master ]
+    branches: [ master, dist_state_mgmt ]
 
 env:
   MSRV: 1.57.0

--- a/.github/workflows/lms.yml
+++ b/.github/workflows/lms.yml
@@ -70,7 +70,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - id: msrv
-        run: echo "::set-output name=msrv::$(grep rust-version Cargo.toml | cut -d'"' -f2-2)"
+        run: echo "msrv=$(grep rust-version Cargo.toml | cut -d'"' -f2-2)" >> $GITHUB_OUTPUT
 
   build:
     needs: set-msrv

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -13,7 +13,7 @@ jobs:
     name: Security Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Cache cargo bin
         uses: actions/cache@v1
         with:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This demo application can be used in the console as follows:
 
 ```
 # Key generation
-# Generates `mykey.priv`, `mykey.pub` with merkle tree height 10 and winternitz parameter 2
+# Generates `mykey.prv`, `mykey.pub` with merkle tree height 10 and winternitz parameter 2
 cargo run --release --example lms-demo -- genkey mykey 10/2 --seed 0123456701234567012345670123456701234567012345670123456701234567
 
 # Signing

--- a/src/hss/reference_impl_private_key.rs
+++ b/src/hss/reference_impl_private_key.rs
@@ -39,7 +39,7 @@ impl<H: HashChain> From<[u8; MAX_SEED_LEN]> for Seed<H> {
     fn from(data: [u8; MAX_SEED_LEN]) -> Self {
         Seed {
             data: ArrayVecZeroize(ArrayVec::from_array_len(data, MAX_SEED_LEN)),
-            phantom: PhantomData::default(),
+            phantom: PhantomData,
         }
     }
 }
@@ -51,7 +51,7 @@ impl<H: HashChain> TryFrom<ArrayVec<[u8; MAX_SEED_LEN]>> for Seed<H> {
         if value.len() == H::OUTPUT_SIZE as usize {
             Ok(Seed {
                 data: ArrayVecZeroize(value),
-                phantom: PhantomData::default(),
+                phantom: PhantomData,
             })
         } else {
             Err("Can only construct seed from data of the HashChain output length")

--- a/src/lm_ots/verify.rs
+++ b/src/lm_ots/verify.rs
@@ -78,7 +78,7 @@ pub fn verify_signature_inmemory<H: HashChain>(
         return false;
     }
 
-    let public_key_candidate = generate_public_key_candiate(
+    let public_key_candidate = generate_public_key_candidate(
         signature,
         &public_key.lms_tree_identifier,
         u32::from_be_bytes(public_key.lms_leaf_identifier),
@@ -88,7 +88,7 @@ pub fn verify_signature_inmemory<H: HashChain>(
     public_key_candidate == public_key.key
 }
 
-pub fn generate_public_key_candiate<H: HashChain>(
+pub fn generate_public_key_candidate<H: HashChain>(
     signature: &InMemoryLmotsSignature<'_, H>,
     lms_tree_identifier: &[u8],
     lms_leaf_identifier: u32,

--- a/src/lms/verify.rs
+++ b/src/lms/verify.rs
@@ -19,7 +19,7 @@ pub fn verify<'a, H: HashChain>(
         return Err(());
     }
 
-    let public_key_canditate = generate_public_key_candiate(signature, public_key, message)?;
+    let public_key_canditate = generate_public_key_candidate(signature, public_key, message)?;
 
     if public_key_canditate.as_slice() == public_key.key {
         Ok(())
@@ -28,7 +28,7 @@ pub fn verify<'a, H: HashChain>(
     }
 }
 
-fn generate_public_key_candiate<'a, H: HashChain>(
+fn generate_public_key_candidate<'a, H: HashChain>(
     signature: &InMemoryLmsSignature<'a, H>,
     public_key: &InMemoryLmsPublicKey<'a, H>,
     message: &[u8],
@@ -40,7 +40,7 @@ fn generate_public_key_candiate<'a, H: HashChain>(
         return Err(());
     }
 
-    let ots_public_key_canditate = lm_ots::verify::generate_public_key_candiate(
+    let ots_public_key_canditate = lm_ots::verify::generate_public_key_candidate(
         &signature.lmots_signature,
         public_key.lms_tree_identifier,
         signature.lms_leaf_identifier,


### PR DESCRIPTION
Changes to fix GitHub CI actions:

- change `PhantomData::Default()` to `PhantomData` as suggested by `rustc`
- remove MIPS toolchain (removed in rust's default cross installation)
- replace `set_output` by `$GITHUB_OUTPUT`
- replace `checkout@v2` by `checkout@v4`
- replace GitHub's outdated rust `actions-rs` by `dtolnay/rust-toolchain`

- The rustc 1.57 still causes troube
- maybe also the actions from `dtolnay/rust-toolchain`

More infos in commits.

There's one change that may not be desired: the branch `dist_state_mgmt` is added for CI